### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,6 @@
 [options]
 install_requires =
-    pandas==1.1.5
     numpy
     pathlib
     scipy
-    matplotlib==3.5.3
     h5py


### PR DESCRIPTION
removed the requirement matplotlib==3.5.3 and pandas==1.1.5 because those packages don't work in the SOLEIL Synchrotron environments